### PR TITLE
feat: Add validation and skip if target version is matched actual version

### DIFF
--- a/.github/workflows/production-sdk.yml
+++ b/.github/workflows/production-sdk.yml
@@ -77,12 +77,25 @@ jobs:
         id: check_version
         run: |
           git fetch origin main
+          
+          # Check if version exists in main branch
           if git show origin/main:setup.py 2>/dev/null | grep -q "VERSION = \"${{ steps.version.outputs.version }}\""; then
             echo "exists=true" >> $GITHUB_OUTPUT
             echo "::notice::Version v${{ steps.version.outputs.version }} already exists in public main. Skipping PR creation."
-          else
-            echo "exists=false" >> $GITHUB_OUTPUT
+            exit 0
           fi
+          
+          # Check if PR with this version already exists
+          PR_COUNT=$(gh pr list --repo ${{ github.repository }} --state open --search "Production SDK v${{ steps.version.outputs.version }} in:title" --json number --jq 'length')
+          if [ "$PR_COUNT" -gt 0 ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "::notice::PR for version v${{ steps.version.outputs.version }} already exists. Skipping PR creation."
+            exit 0
+          fi
+          
+          echo "exists=false" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Generate SDK using Perl script
         if: steps.check_version.outputs.exists == 'false'


### PR DESCRIPTION
## Add Version and PR Existence Validation to Staging Workflow

This PR enhances the staging SDK workflow with duplicate prevention checks to avoid unnecessary SDK regeneration and PR creation.

### Changes

Added validation step that checks:
- Whether the current swagger version already exists in the main branch
- Whether an open PR with the same version already exists